### PR TITLE
Add more regex test example

### DIFF
--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -201,6 +201,7 @@ class FastRouteRouterTest extends TestCase
             'encoded-space'   => ['/foo/{id:.+}', '/foo/b%20ar', 'b ar'],
             'encoded-slash'   => ['/foo/{id:.+}', '/foo/b%2Fr', 'b/r'],
             'encoded-unicode' => ['/foo/{id:.+}', '/foo/bar-%E6%B8%AC%E8%A9%A6', 'bar-測試'],
+            'encoded-unicode-regex' => ['/foo/{id:[\w\-\%]+}', '/foo/bar-%E6%B8%AC%E8%A9%A6', 'bar-測試'],
             'encoded-regex'   => ['/foo/{id:bär}', '/foo/b%C3%A4r', 'bär'],
             'unencoded-regex' => ['/foo/{id:bär}', '/foo/bär', 'bär'],
         ];


### PR DESCRIPTION
### Description
Added a test that fails to match despite the regex is matching the requested uri
https://regex101.com/r/j6SilR/1

The problem is on urldecoding the path before regex and i seems to be a global problem with special chars

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
