### PR TITLE
Upgrade `nikic/fast-route` to version `2.0.0-beta1`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,16 +39,16 @@
         "fig/http-message-util": "^1.1.2",
         "laminas/laminas-stdlib": "^3.19.0",
         "mezzio/mezzio-router": "^3.18 || ^4.0.1",
-        "nikic/fast-route": "^1.2",
+        "nikic/fast-route": "^2.0.0-beta1",
         "psr/container": "^1.0 || ^2.0",
         "psr/http-message": "^1.0.1 || ^2.0.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~3.1.0",
-        "laminas/laminas-diactoros": "^3.6.0",
-        "laminas/laminas-stratigility": "^4.2.0",
+        "laminas/laminas-diactoros": "^3.8.0",
+        "laminas/laminas-stratigility": "^4.3.0",
         "mikey179/vfsstream": "^1.6.12",
-        "phpunit/phpunit": "^11.5.42",
+        "phpunit/phpunit": "^11.5.44",
         "psalm/plugin-phpunit": "^0.19.5",
         "vimeo/psalm": "^6.13.1"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fe0b842db5f91fd8eb2a8fbe5f63c5db",
+    "content-hash": "7de1dc9618954abfeac65892d100f2a6",
     "packages": [
         {
             "name": "fig/http-message-util",
@@ -204,25 +204,38 @@
         },
         {
             "name": "nikic/fast-route",
-            "version": "v1.3.0",
+            "version": "2.0.0-beta1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/FastRoute.git",
-                "reference": "181d480e08d9476e61381e04a71b34dc0432e812"
+                "reference": "d3ada013d0f683ad2a8d0614fc97917a6ab72ce9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/181d480e08d9476e61381e04a71b34dc0432e812",
-                "reference": "181d480e08d9476e61381e04a71b34dc0432e812",
+                "url": "https://api.github.com/repos/nikic/FastRoute/zipball/d3ada013d0f683ad2a8d0614fc97917a6ab72ce9",
+                "reference": "d3ada013d0f683ad2a8d0614fc97917a6ab72ce9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=5.4.0"
+                "php": ">=8.1.0",
+                "psr/simple-cache": "^2.0 || ^3.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8.35|~5.7"
+                "lcobucci/coding-standard": "^11.0",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.10",
+                "phpstan/phpstan-deprecation-rules": "^1.1",
+                "phpstan/phpstan-phpunit": "^1.3",
+                "phpstan/phpstan-strict-rules": "^1.5",
+                "phpunit/phpunit": "^10.3"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0-dev"
+                }
+            },
             "autoload": {
                 "files": [
                     "src/functions.php"
@@ -248,9 +261,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/FastRoute/issues",
-                "source": "https://github.com/nikic/FastRoute/tree/master"
+                "source": "https://github.com/nikic/FastRoute/tree/2.0.0-beta1"
             },
-            "time": "2018-02-13T20:26:39+00:00"
+            "time": "2024-03-04T23:46:43+00:00"
         },
         {
             "name": "psr/container",
@@ -525,6 +538,57 @@
                 "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
             },
             "time": "2023-04-11T06:14:47+00:00"
+        },
+        {
+            "name": "psr/simple-cache",
+            "version": "3.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/simple-cache.git",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/simple-cache/zipball/764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "reference": "764e0b3939f5ca87cb904f570ef9be2d78a07865",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\SimpleCache\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interfaces for simple caching",
+            "keywords": [
+                "cache",
+                "caching",
+                "psr",
+                "psr-16",
+                "simple-cache"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/simple-cache/tree/3.0.0"
+            },
+            "time": "2021-10-29T13:26:27+00:00"
         },
         {
             "name": "webmozart/assert",
@@ -1714,29 +1778,29 @@
         },
         {
             "name": "dealerdirect/phpcodesniffer-composer-installer",
-            "version": "v1.1.2",
+            "version": "v1.2.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/composer-installer.git",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1"
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
-                "reference": "e9cf5e4bbf7eeaf9ef5db34938942602838fc2b1",
+                "url": "https://api.github.com/repos/PHPCSStandards/composer-installer/zipball/845eb62303d2ca9b289ef216356568ccc075ffd1",
+                "reference": "845eb62303d2ca9b289ef216356568ccc075ffd1",
                 "shasum": ""
             },
             "require": {
                 "composer-plugin-api": "^2.2",
                 "php": ">=5.4",
-                "squizlabs/php_codesniffer": "^2.0 || ^3.1.0 || ^4.0"
+                "squizlabs/php_codesniffer": "^3.1.0 || ^4.0"
             },
             "require-dev": {
                 "composer/composer": "^2.2",
                 "ext-json": "*",
                 "ext-zip": "*",
                 "php-parallel-lint/php-parallel-lint": "^1.4.0",
-                "phpcompatibility/php-compatibility": "^9.0",
+                "phpcompatibility/php-compatibility": "^9.0 || ^10.0.0@dev",
                 "yoast/phpunit-polyfills": "^1.0"
             },
             "type": "composer-plugin",
@@ -1806,7 +1870,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-07-17T20:45:56+00:00"
+            "time": "2025-11-11T04:32:07+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -2350,33 +2414,38 @@
         },
         {
             "name": "league/uri",
-            "version": "7.5.1",
+            "version": "7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri.git",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430"
+                "reference": "f625804987a0a9112d954f9209d91fec52182344"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri/zipball/81fb5145d2644324614cc532b28efd0215bda430",
-                "reference": "81fb5145d2644324614cc532b28efd0215bda430",
+                "url": "https://api.github.com/repos/thephpleague/uri/zipball/f625804987a0a9112d954f9209d91fec52182344",
+                "reference": "f625804987a0a9112d954f9209d91fec52182344",
                 "shasum": ""
             },
             "require": {
-                "league/uri-interfaces": "^7.5",
-                "php": "^8.1"
+                "league/uri-interfaces": "^7.6",
+                "php": "^8.1",
+                "psr/http-factory": "^1"
             },
             "conflict": {
                 "league/uri-schemes": "^1.0"
             },
             "suggest": {
                 "ext-bcmath": "to improve IPV4 host parsing",
+                "ext-dom": "to convert the URI into an HTML anchor tag",
                 "ext-fileinfo": "to create Data URI from file contennts",
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
+                "ext-uri": "to use the PHP native URI class",
                 "jeremykendall/php-domain-parser": "to resolve Public Suffix and Top Level Domain",
                 "league/uri-components": "Needed to easily manipulate URI objects components",
+                "league/uri-polyfill": "Needed to backport the PHP URI extension for older versions of PHP",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -2404,6 +2473,7 @@
             "description": "URI manipulation library",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
+                "URN",
                 "data-uri",
                 "file-uri",
                 "ftp",
@@ -2416,9 +2486,11 @@
                 "psr-7",
                 "query-string",
                 "querystring",
+                "rfc2141",
                 "rfc3986",
                 "rfc3987",
                 "rfc6570",
+                "rfc8141",
                 "uri",
                 "uri-template",
                 "url",
@@ -2428,7 +2500,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri/tree/7.5.1"
+                "source": "https://github.com/thephpleague/uri/tree/7.6.0"
             },
             "funding": [
                 {
@@ -2436,26 +2508,25 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:40:02+00:00"
+            "time": "2025-11-18T12:17:23+00:00"
         },
         {
             "name": "league/uri-interfaces",
-            "version": "7.5.0",
+            "version": "7.6.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/uri-interfaces.git",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742"
+                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
-                "reference": "08cfc6c4f3d811584fb09c37e2849e6a7f9b0742",
+                "url": "https://api.github.com/repos/thephpleague/uri-interfaces/zipball/ccbfb51c0445298e7e0b7f4481b942f589665368",
+                "reference": "ccbfb51c0445298e7e0b7f4481b942f589665368",
                 "shasum": ""
             },
             "require": {
                 "ext-filter": "*",
                 "php": "^8.1",
-                "psr/http-factory": "^1",
                 "psr/http-message": "^1.1 || ^2.0"
             },
             "suggest": {
@@ -2463,6 +2534,7 @@
                 "ext-gmp": "to improve IPV4 host parsing",
                 "ext-intl": "to handle IDN host with the best performance",
                 "php-64bit": "to improve IPV4 host parsing",
+                "rowbot/url": "to handle WHATWG URL",
                 "symfony/polyfill-intl-idn": "to handle IDN host via the Symfony polyfill if ext-intl is not present"
             },
             "type": "library",
@@ -2487,7 +2559,7 @@
                     "homepage": "https://nyamsprod.com"
                 }
             ],
-            "description": "Common interfaces and classes for URI representation and interaction",
+            "description": "Common tools for parsing and resolving RFC3987/RFC3986 URI",
             "homepage": "https://uri.thephpleague.com",
             "keywords": [
                 "data-uri",
@@ -2512,7 +2584,7 @@
                 "docs": "https://uri.thephpleague.com",
                 "forum": "https://thephpleague.slack.com",
                 "issues": "https://github.com/thephpleague/uri-src/issues",
-                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.5.0"
+                "source": "https://github.com/thephpleague/uri-interfaces/tree/7.6.0"
             },
             "funding": [
                 {
@@ -2520,7 +2592,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-08T08:18:47+00:00"
+            "time": "2025-11-18T12:17:23+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -2916,16 +2988,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.6.3",
+            "version": "5.6.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9"
+                "reference": "90a04bcbf03784066f16038e87e23a0a83cee3c2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/94f8051919d1b0369a6bcc7931d679a511c03fe9",
-                "reference": "94f8051919d1b0369a6bcc7931d679a511c03fe9",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/90a04bcbf03784066f16038e87e23a0a83cee3c2",
+                "reference": "90a04bcbf03784066f16038e87e23a0a83cee3c2",
                 "shasum": ""
             },
             "require": {
@@ -2974,22 +3046,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.3"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.6.4"
             },
-            "time": "2025-08-01T19:43:32+00:00"
+            "time": "2025-11-17T21:13:10+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.10.0",
+            "version": "1.12.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a"
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/679e3ce485b99e84c775d28e2e96fade9a7fb50a",
-                "reference": "679e3ce485b99e84c775d28e2e96fade9a7fb50a",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/92a98ada2b93d9b201a613cb5a33584dde25f195",
+                "reference": "92a98ada2b93d9b201a613cb5a33584dde25f195",
                 "shasum": ""
             },
             "require": {
@@ -3032,9 +3104,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.10.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.12.0"
             },
-            "time": "2024-11-09T15:12:26+00:00"
+            "time": "2025-11-21T15:09:14+00:00"
         },
         {
             "name": "phpstan/phpdoc-parser",
@@ -3420,16 +3492,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.43",
+            "version": "11.5.44",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924"
+                "reference": "c346885c95423eda3f65d85a194aaa24873cda82"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924",
-                "reference": "c6b89b6cf4324a8b4cb86e1f5dfdd6c9e0371924",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c346885c95423eda3f65d85a194aaa24873cda82",
+                "reference": "c346885c95423eda3f65d85a194aaa24873cda82",
                 "shasum": ""
             },
             "require": {
@@ -3501,7 +3573,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.43"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.44"
             },
             "funding": [
                 {
@@ -3525,7 +3597,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-10-30T08:39:39+00:00"
+            "time": "2025-11-13T07:17:35+00:00"
         },
         {
             "name": "psalm/plugin-phpunit",
@@ -4760,16 +4832,16 @@
         },
         {
             "name": "spatie/array-to-xml",
-            "version": "3.4.0",
+            "version": "3.4.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/spatie/array-to-xml.git",
-                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67"
+                "reference": "6a740f39415aee8886aea10333403adc77d50791"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
-                "reference": "7dcfc67d60b0272926dabad1ec01f6b8a5fb5e67",
+                "url": "https://api.github.com/repos/spatie/array-to-xml/zipball/6a740f39415aee8886aea10333403adc77d50791",
+                "reference": "6a740f39415aee8886aea10333403adc77d50791",
                 "shasum": ""
             },
             "require": {
@@ -4812,7 +4884,7 @@
                 "xml"
             ],
             "support": {
-                "source": "https://github.com/spatie/array-to-xml/tree/3.4.0"
+                "source": "https://github.com/spatie/array-to-xml/tree/3.4.1"
             },
             "funding": [
                 {
@@ -4824,7 +4896,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-12-16T12:45:15+00:00"
+            "time": "2025-11-12T10:32:50+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -5786,16 +5858,16 @@
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.3",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2"
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
-                "reference": "737eda637ed5e28c3413cb1ebe8bb52cbf1ca7a2",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
+                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
                 "shasum": ""
             },
             "require": {
@@ -5824,7 +5896,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.2.3"
+                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
             },
             "funding": [
                 {
@@ -5832,7 +5904,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-03-03T12:36:25+00:00"
+            "time": "2025-11-17T20:03:58+00:00"
         },
         {
             "name": "vimeo/psalm",
@@ -6010,7 +6082,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": {},
+    "stability-flags": {
+        "nikic/fast-route": 10
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,47 +1,31 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="6.10.0@9c0add4eb88d4b169ac04acb7c679918cbb9c252">
+<files psalm-version="6.13.1@1e3b7f0a8ab32b23197b91107adc0a7ed8a05b51">
   <file src="src/FastRouteRouter.php">
+    <InternalMethod>
+      <code><![CDATA[new GroupCountBased($data)]]></code>
+    </InternalMethod>
     <InvalidArgument>
       <code><![CDATA[static function (): void {
         }]]></code>
     </InvalidArgument>
-    <MixedArgument>
-      <code><![CDATA[$part[0]]]></code>
-      <code><![CDATA[$part[1]]]></code>
-    </MixedArgument>
     <MixedArgumentTypeCoercion>
       <code><![CDATA[$missingParameters]]></code>
       <code><![CDATA[$params]]></code>
     </MixedArgumentTypeCoercion>
     <MixedArrayAccess>
       <code><![CDATA[$part[0]]]></code>
-      <code><![CDATA[$part[0]]]></code>
-      <code><![CDATA[$part[0]]]></code>
-      <code><![CDATA[$part[0]]]></code>
-      <code><![CDATA[$part[1]]]></code>
-      <code><![CDATA[$part[1]]]></code>
     </MixedArrayAccess>
     <MixedArrayOffset>
       <code><![CDATA[$substitutions[$param]]]></code>
-      <code><![CDATA[$substitutions[$part[0]]]]></code>
-      <code><![CDATA[$substitutions[$part[0]]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
       <code><![CDATA[$missingParameters[]]]></code>
       <code><![CDATA[$param]]></code>
       <code><![CDATA[$part]]></code>
-      <code><![CDATA[$part]]></code>
     </MixedAssignment>
     <MixedOperand>
-      <code><![CDATA[$part[1]]]></code>
       <code><![CDATA[$substitutions[$part[0]]]]></code>
     </MixedOperand>
-    <PossiblyUndefinedArrayOffset>
-      <code><![CDATA[$result[1]]]></code>
-    </PossiblyUndefinedArrayOffset>
-    <RedundantCastGivenDocblockType>
-      <code><![CDATA[(array) $this->router->getData()]]></code>
-    </RedundantCastGivenDocblockType>
     <UnresolvableInclude>
       <code><![CDATA[include $this->cacheFile]]></code>
     </UnresolvableInclude>

--- a/src/FastRouteRouter.php
+++ b/src/FastRouteRouter.php
@@ -4,9 +4,14 @@ declare(strict_types=1);
 
 namespace Mezzio\Router;
 
+use FastRoute\ConfigureRoutes;
+use FastRoute\DataGenerator;
 use FastRoute\DataGenerator\GroupCountBased as RouteGenerator;
 use FastRoute\Dispatcher;
 use FastRoute\Dispatcher\GroupCountBased;
+use FastRoute\Dispatcher\Result\Matched;
+use FastRoute\Dispatcher\Result\MethodNotAllowed;
+use FastRoute\Dispatcher\Result\NotMatched;
 use FastRoute\RouteCollector;
 use FastRoute\RouteParser\Std as RouteParser;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
@@ -46,19 +51,7 @@ use const E_WARNING;
  *     cache_file?: string,
  *     ...
  * }
- * @psalm-type FastRouteNotFoundResult = array{
- *     0: Dispatcher::NOT_FOUND,
- * }
- * @psalm-type FastRouteBadMethodResult = array{
- *     0: Dispatcher::METHOD_NOT_ALLOWED,
- *     1: list<non-empty-string>,
- * }
- * @psalm-type FastRouteFoundResult = array{
- *     0: Dispatcher::FOUND,
- *     1: non-empty-string,
- *     2: array<string, mixed>
- * }
- * @psalm-type FastRouteResult = FastRouteNotFoundResult|FastRouteBadMethodResult|FastRouteFoundResult
+ * @psalm-import-type RouteData from DataGenerator
  */
 class FastRouteRouter implements RouterInterface
 {
@@ -104,11 +97,13 @@ class FastRouteRouter implements RouterInterface
      */
     private string $cacheFile = 'data/cache/fastroute.php.cache';
 
-    /** @var callable(array|object): Dispatcher|null A factory callback that can return a dispatcher. */
+    /** @var callable(RouteData): Dispatcher|null A factory callback that can return a dispatcher. */
     private $dispatcherCallback;
 
     /**
      * Cached data used by the dispatcher.
+     *
+     * @var RouteData|array<never, never>
      */
     private array $dispatchData = [];
 
@@ -121,7 +116,7 @@ class FastRouteRouter implements RouterInterface
     /**
      * FastRoute router
      */
-    private ?RouteCollector $router = null;
+    private ?ConfigureRoutes $router = null;
 
     /**
      * All attached routes as Route instances
@@ -149,7 +144,7 @@ class FastRouteRouter implements RouterInterface
      *   RouteGenerator.
      * - A callable that returns a GroupCountBased dispatcher will be created.
      *
-     * @param null|RouteCollector $router If not provided, a default
+     * @param null|RouteCollector|ConfigureRoutes $router If not provided, a default
      *     implementation will be used.
      * @param null|callable(array|object): Dispatcher $dispatcherFactory Callable that will return a
      *     FastRoute dispatcher.
@@ -157,7 +152,7 @@ class FastRouteRouter implements RouterInterface
      * @psalm-param FastRouteConfig $config
      */
     public function __construct(
-        ?RouteCollector $router = null,
+        ConfigureRoutes|RouteCollector|null $router = null,
         ?callable $dispatcherFactory = null,
         ?array $config = null
     ) {
@@ -219,13 +214,10 @@ class FastRouteRouter implements RouterInterface
         $dispatcher = $this->getDispatcher($dispatchData);
         $result     = $dispatcher->dispatch($method, $path);
 
-        if ($result[0] !== Dispatcher::FOUND) {
-            /** @psalm-var FastRouteNotFoundResult|FastRouteBadMethodResult $result */
-
+        if (! $result instanceof Matched) {
             return $this->marshalFailedRoute($result);
         }
 
-        /** @psalm-var FastRouteFoundResult $result */
         return $this->marshalMatchedRoute($result, $method);
     }
 
@@ -364,9 +356,9 @@ class FastRouteRouter implements RouterInterface
      * (which should be derived from the router's getData() method); this
      * approach is done to allow testing against the dispatcher.
      *
-     * @param array|object $data Data from RouteCollection::getData()
+     * @param RouteData $data Data from {@link ConfigureRoutes::processedRoutes()}
      */
-    private function getDispatcher($data): Dispatcher
+    private function getDispatcher(array $data): Dispatcher
     {
         if ($this->dispatcherCallback === null) {
             $this->dispatcherCallback = $this->createDispatcherCallback();
@@ -380,11 +372,11 @@ class FastRouteRouter implements RouterInterface
     /**
      * Return a default implementation of a callback that can return a Dispatcher.
      *
-     * @return callable(array|object): GroupCountBased
+     * @return callable(RouteData): GroupCountBased
      */
     private function createDispatcherCallback(): callable
     {
-        return static fn($data): GroupCountBased => new GroupCountBased($data);
+        return static fn(array $data): GroupCountBased => new GroupCountBased($data);
     }
 
     /**
@@ -392,13 +384,11 @@ class FastRouteRouter implements RouterInterface
      *
      * If the failure was due to the HTTP method, passes the allowed HTTP
      * methods to the factory.
-     *
-     * @param FastRouteNotFoundResult|FastRouteBadMethodResult $result
      */
-    private function marshalFailedRoute(array $result): RouteResult
+    private function marshalFailedRoute(MethodNotAllowed|NotMatched $result): RouteResult
     {
-        if ($result[0] === Dispatcher::METHOD_NOT_ALLOWED) {
-            return RouteResult::fromRouteFailure($result[1]);
+        if ($result instanceof MethodNotAllowed) {
+            return RouteResult::fromRouteFailure($result->allowedMethods);
         }
 
         return RouteResult::fromRouteFailure(Route::HTTP_METHOD_ANY);
@@ -406,12 +396,11 @@ class FastRouteRouter implements RouterInterface
 
     /**
      * Marshals a route result based on the results of matching and the current HTTP method.
-     *
-     * @param FastRouteFoundResult $result
      */
-    private function marshalMatchedRoute(array $result, string $method): RouteResult
+    private function marshalMatchedRoute(Matched $result, string $method): RouteResult
     {
-        $path  = $result[1];
+        $path = $result->handler;
+        assert(is_string($path));
         $route = array_reduce(
             $this->routes,
             static function (Route|false $matched, Route $route) use ($path, $method): Route|false {
@@ -436,7 +425,7 @@ class FastRouteRouter implements RouterInterface
             return $this->marshalMethodNotAllowedResult($result);
         }
 
-        $params = $result[2];
+        $params = $result->variables;
 
         $options = $route->getOptions();
         if (isset($options['defaults']) && is_array($options['defaults'])) {
@@ -476,7 +465,7 @@ class FastRouteRouter implements RouterInterface
             $methods = self::HTTP_METHODS_STANDARD;
         }
 
-        assert($this->router instanceof RouteCollector);
+        assert($this->router instanceof ConfigureRoutes);
 
         $this->router->addRoute($methods, $route->getPath(), $route->getPath());
     }
@@ -486,16 +475,20 @@ class FastRouteRouter implements RouterInterface
      * FastRoute data generator.
      *
      * If caching is enabled, store the freshly generated data to file.
+     *
+     * @return RouteData
      */
     private function getDispatchData(): array
     {
         if ($this->hasCache) {
+            /** @psalm-var RouteData */
             return $this->dispatchData;
         }
 
-        assert($this->router instanceof RouteCollector);
+        assert($this->router instanceof ConfigureRoutes);
 
-        $dispatchData = (array) $this->router->getData();
+        /** @psalm-var RouteData $dispatchData Not quite accurate because the returned data has an extra key */
+        $dispatchData = $this->router->processedRoutes();
 
         if ($this->cacheEnabled) {
             $this->cacheDispatchData($dispatchData);
@@ -528,6 +521,8 @@ class FastRouteRouter implements RouterInterface
                 $this->cacheFile
             ));
         }
+
+        /** @psalm-var RouteData $dispatchData Psalm cannot infer what comes out of the cache */
 
         $this->hasCache     = true;
         $this->dispatchData = $dispatchData;
@@ -575,10 +570,10 @@ class FastRouteRouter implements RouterInterface
         );
     }
 
-    /** @param FastRouteFoundResult $result */
-    private function marshalMethodNotAllowedResult(array $result): RouteResult
+    private function marshalMethodNotAllowedResult(Matched $result): RouteResult
     {
-        $path           = $result[1];
+        $path = $result->handler;
+        assert(is_string($path));
         $allowedMethods = array_reduce(
             $this->routes,
             /**

--- a/test/FastRouteRouterTest.php
+++ b/test/FastRouteRouterTest.php
@@ -5,7 +5,11 @@ declare(strict_types=1);
 namespace MezzioTest\Router;
 
 use Closure;
+use FastRoute\ConfigureRoutes;
 use FastRoute\Dispatcher;
+use FastRoute\Dispatcher\Result\Matched;
+use FastRoute\Dispatcher\Result\MethodNotAllowed;
+use FastRoute\Dispatcher\Result\NotMatched;
 use FastRoute\RouteCollector;
 use Fig\Http\Message\RequestMethodInterface as RequestMethod;
 use Laminas\Diactoros\Response\TextResponse;
@@ -36,16 +40,14 @@ use function unlink;
 /** @psalm-import-type FastRouteConfig from FastRouteRouter */
 final class FastRouteRouterTest extends TestCase
 {
-    /** @var RouteCollector&MockObject */
-    private RouteCollector $fastRouter;
-    /** @var Dispatcher&MockObject */
-    private Dispatcher $dispatcher;
+    private ConfigureRoutes&MockObject $fastRouter;
+    private Dispatcher&MockObject $dispatcher;
     /** @var Closure(): Dispatcher */
     private Closure $dispatchCallback;
 
     protected function setUp(): void
     {
-        $this->fastRouter       = $this->createMock(RouteCollector::class);
+        $this->fastRouter       = $this->createMock(ConfigureRoutes::class);
         $this->dispatcher       = $this->createMock(Dispatcher::class);
         $this->dispatchCallback = fn(): Dispatcher => $this->dispatcher;
     }
@@ -54,7 +56,7 @@ final class FastRouteRouterTest extends TestCase
     {
         return new FastRouteRouter(
             $this->fastRouter,
-            $this->dispatchCallback
+            $this->dispatchCallback,
         );
     }
 
@@ -97,14 +99,12 @@ final class FastRouteRouterTest extends TestCase
             ->with([RequestMethod::METHOD_GET], '/foo', '/foo');
 
         $this->fastRouter->expects(self::once())
-            ->method('getData');
+            ->method('processedRoutes');
 
         $this->dispatcher->expects(self::once())
             ->method('dispatch')
             ->with(RequestMethod::METHOD_GET, '/foo')
-            ->willReturn([
-                Dispatcher::NOT_FOUND,
-            ]);
+            ->willReturn($this->notFound());
 
         $router = $this->getRouter();
         $router->addRoute($route);
@@ -137,7 +137,7 @@ final class FastRouteRouterTest extends TestCase
             ->with(
                 FastRouteRouter::HTTP_METHODS_STANDARD,
                 '/foo',
-                '/foo'
+                '/foo',
             );
 
         $router = $this->getRouter();
@@ -159,24 +159,20 @@ final class FastRouteRouterTest extends TestCase
         $uri     = new Uri('/foo');
         $request = (new ServerRequestFactory())->createServerRequest(
             RequestMethod::METHOD_GET,
-            $uri
+            $uri,
         );
 
         $this->dispatcher->expects(self::once())
             ->method('dispatch')
             ->with(RequestMethod::METHOD_GET, '/foo')
-            ->willReturn([
-                Dispatcher::FOUND,
-                '/foo',
-                ['bar' => 'baz'],
-            ]);
+            ->willReturn($this->successResult('/foo', ['bar' => 'baz']));
 
         $this->fastRouter->expects(self::once())
             ->method('addRoute')
             ->with([RequestMethod::METHOD_GET], '/foo', '/foo');
 
         $this->fastRouter->expects(self::once())
-            ->method('getData');
+            ->method('processedRoutes');
 
         $router = $this->getRouter();
         $router->addRoute($route); // Must add, so we can determine middleware later
@@ -226,7 +222,7 @@ final class FastRouteRouterTest extends TestCase
     public function testMatchWithUrlEncodedSpecialChars(
         string $routePath,
         string $requestPath,
-        string $expectedId
+        string $expectedId,
     ): void {
         $request = $this->createServerRequest($requestPath, RequestMethod::METHOD_GET);
 
@@ -241,7 +237,7 @@ final class FastRouteRouterTest extends TestCase
         self::assertSame('foo', $routeResult->getMatchedRouteName());
         self::assertSame(
             ['id' => $expectedId],
-            $routeResult->getMatchedParams()
+            $routeResult->getMatchedParams(),
         );
     }
 
@@ -258,7 +254,7 @@ final class FastRouteRouterTest extends TestCase
 
     #[DataProvider('idemPotentMethods')]
     public function testRouteNotSpecifyingOptionsImpliesOptionsIsSupportedAndMatchesWhenGetOrHeadIsAllowed(
-        string $method
+        string $method,
     ): void {
         $route = new Route('/foo', self::getMiddleware(), [RequestMethod::METHOD_POST, $method]);
 
@@ -334,17 +330,14 @@ final class FastRouteRouterTest extends TestCase
         $this->dispatcher->expects(self::once())
             ->method('dispatch')
             ->with(RequestMethod::METHOD_GET, '/foo')
-            ->willReturn([
-                Dispatcher::METHOD_NOT_ALLOWED,
-                [RequestMethod::METHOD_POST],
-            ]);
+            ->willReturn($this->methodNotAllowed([RequestMethod::METHOD_POST]));
 
         $this->fastRouter->expects(self::once())
             ->method('addRoute')
             ->with([RequestMethod::METHOD_POST], '/foo', '/foo');
 
         $this->fastRouter->expects(self::once())
-            ->method('getData');
+            ->method('processedRoutes');
 
         $router = $this->getRouter();
         $router->addRoute($route); // Must add, so we can determine middleware later
@@ -363,22 +356,20 @@ final class FastRouteRouterTest extends TestCase
 
         $request = (new ServerRequestFactory())->createServerRequest(
             RequestMethod::METHOD_GET,
-            $uri
+            $uri,
         );
 
         $this->dispatcher->expects(self::once())
             ->method('dispatch')
             ->with(RequestMethod::METHOD_GET, '/bar')
-            ->willReturn([
-                Dispatcher::NOT_FOUND,
-            ]);
+            ->willReturn($this->notFound());
 
         $this->fastRouter->expects(self::once())
             ->method('addRoute')
             ->with([RequestMethod::METHOD_GET], '/foo', '/foo');
 
         $this->fastRouter->expects(self::once())
-            ->method('getData');
+            ->method('processedRoutes');
 
         $router = $this->getRouter();
         $router->addRoute($route); // Must add, so we can determine middleware later
@@ -451,7 +442,7 @@ final class FastRouteRouterTest extends TestCase
             '/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]',
             self::getMiddleware(),
             [RequestMethod::METHOD_GET],
-            'limit'
+            'limit',
         );
         $route->setOptions([
             'defaults' => [
@@ -480,7 +471,7 @@ final class FastRouteRouterTest extends TestCase
             '/page[/{page:\d+}/{locale:[a-z]{2}}[/optional-{extra:\w+}]]',
             self::getMiddleware(),
             [RequestMethod::METHOD_GET],
-            'limit'
+            'limit',
         );
         $route->setOptions([
             'defaults' => 'invalid value for defaults',
@@ -501,24 +492,20 @@ final class FastRouteRouterTest extends TestCase
 
         $request = (new ServerRequestFactory())->createServerRequest(
             RequestMethod::METHOD_GET,
-            $uri
+            $uri,
         );
 
         $this->dispatcher->expects(self::once())
             ->method('dispatch')
             ->with(RequestMethod::METHOD_GET, '/foo')
-            ->willReturn([
-                Dispatcher::FOUND,
-                '/foo',
-                ['bar' => 'baz'],
-            ]);
+            ->willReturn($this->successResult('/foo', ['bar' => 'baz']));
 
         $this->fastRouter->expects(self::once())
             ->method('addRoute')
             ->with([RequestMethod::METHOD_GET], '/foo', '/foo');
 
         $this->fastRouter->expects(self::once())
-            ->method('getData');
+            ->method('processedRoutes');
 
         $router = $this->getRouter();
         $router->addRoute($route); // Must add, so we can determine middleware later
@@ -571,7 +558,7 @@ final class FastRouteRouterTest extends TestCase
     #[DataProvider('uriGeneratorDataProvider')]
     public function testUriGenerationSubstitutionsWithDefaultsAndOptionalParameters(
         string $expectedUri,
-        array $params
+        array $params,
     ): void {
         $router = new FastRouteRouter();
 
@@ -614,7 +601,7 @@ final class FastRouteRouterTest extends TestCase
     #[DataProvider('uriGeneratorWithPartialDefaultsDataProvider')]
     public function testUriGenerationSubstitutionsWithPartialDefaultsAndOptionalParameters(
         string $expectedUri,
-        array $params
+        array $params,
     ): void {
         $router = new FastRouteRouter();
 
@@ -641,7 +628,7 @@ final class FastRouteRouterTest extends TestCase
 
     private function createServerRequest(
         string $path,
-        string $method = RequestMethod::METHOD_GET
+        string $method = RequestMethod::METHOD_GET,
     ): ServerRequestInterface {
         $uri = new Uri($path);
 
@@ -729,7 +716,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
             [],
             '/foo/my-id',
-            RequestMethod::METHOD_GET
+            RequestMethod::METHOD_GET,
         );
 
         $result = $router->match($request);
@@ -751,7 +738,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
             [],
             '/foo/var',
-            RequestMethod::METHOD_GET
+            RequestMethod::METHOD_GET,
         );
 
         $result = $router->match($request);
@@ -774,7 +761,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
             [],
             '/bar',
-            RequestMethod::METHOD_GET
+            RequestMethod::METHOD_GET,
         );
 
         $result = $router->match($request);
@@ -797,7 +784,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
             [],
             '/foo',
-            RequestMethod::METHOD_GET
+            RequestMethod::METHOD_GET,
         );
 
         $this->expectException(InvalidCacheDirectoryException::class);
@@ -819,7 +806,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
             [],
             '/foo',
-            RequestMethod::METHOD_GET
+            RequestMethod::METHOD_GET,
         );
 
         $this->expectException(InvalidCacheDirectoryException::class);
@@ -841,7 +828,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_GET],
             [],
             '/foo',
-            RequestMethod::METHOD_GET
+            RequestMethod::METHOD_GET,
         );
 
         $this->expectException(InvalidCacheException::class);
@@ -878,7 +865,7 @@ final class FastRouteRouterTest extends TestCase
             ['REQUEST_METHOD' => RequestMethod::METHOD_HEAD],
             [],
             '/bar',
-            RequestMethod::METHOD_HEAD
+            RequestMethod::METHOD_HEAD,
         );
 
         $result = $router->match($request);
@@ -887,7 +874,7 @@ final class FastRouteRouterTest extends TestCase
         self::assertTrue($result->isFailure());
         self::assertSame(
             [RequestMethod::METHOD_GET, RequestMethod::METHOD_POST, RequestMethod::METHOD_DELETE],
-            $result->getAllowedMethods()
+            $result->getAllowedMethods(),
         );
     }
 
@@ -898,11 +885,7 @@ final class FastRouteRouterTest extends TestCase
         $dispatcher->expects(self::once())
             ->method('dispatch')
             ->with(RequestMethod::METHOD_GET, '/foo')
-            ->willReturn([
-                Dispatcher::FOUND,
-                '/foo',
-                [],
-            ]);
+            ->willReturn($this->successResult('/foo'));
 
         $callable = fn(): Dispatcher => $dispatcher;
 
@@ -914,5 +897,37 @@ final class FastRouteRouterTest extends TestCase
 
         self::assertTrue($result->isSuccess());
         self::assertFalse($result->isFailure());
+    }
+
+    /**
+     * @psalm-suppress InaccessibleProperty
+     * @param array<string, string> $params
+     * @param array<string, scalar> $extra
+     */
+    private function successResult(string $path, array $params = [], array $extra = []): Matched
+    {
+        $result                  = new Matched();
+        $result->handler         = $path;
+        $result->variables       = $params;
+        $result->extraParameters = $extra;
+
+        return $result;
+    }
+
+    private function notFound(): NotMatched
+    {
+        return new NotMatched();
+    }
+
+    /**
+     * @psalm-suppress InaccessibleProperty
+     * @param non-empty-list<string> $allowed
+     */
+    private function methodNotAllowed(array $allowed): MethodNotAllowed
+    {
+        $result                 = new MethodNotAllowed();
+        $result->allowedMethods = $allowed;
+
+        return $result;
     }
 }

--- a/tools/crc/composer.json
+++ b/tools/crc/composer.json
@@ -1,5 +1,5 @@
 {
     "require-dev": {
-        "maglnet/composer-require-checker": "^4.16.1"
+        "maglnet/composer-require-checker": "^4.18.0"
     }
 }

--- a/tools/crc/composer.lock
+++ b/tools/crc/composer.lock
@@ -4,36 +4,112 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d19687b9ba9a48aee1fbbbd8bff0b4f",
+    "content-hash": "e0b0bed84c73cd3a510add27e26d67b9",
     "packages": [],
     "packages-dev": [
         {
-            "name": "maglnet/composer-require-checker",
-            "version": "4.17.0",
+            "name": "azjezz/psl",
+            "version": "3.3.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/maglnet/ComposerRequireChecker.git",
-                "reference": "c4aeb5882988a23b22216ecf3e934ec50c072a40"
+                "url": "https://github.com/azjezz/psl.git",
+                "reference": "78078f2c505473d2a28319ffe426b2a82ac76790"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/maglnet/ComposerRequireChecker/zipball/c4aeb5882988a23b22216ecf3e934ec50c072a40",
-                "reference": "c4aeb5882988a23b22216ecf3e934ec50c072a40",
+                "url": "https://api.github.com/repos/azjezz/psl/zipball/78078f2c505473d2a28319ffe426b2a82ac76790",
+                "reference": "78078f2c505473d2a28319ffe426b2a82ac76790",
                 "shasum": ""
             },
             "require": {
+                "ext-bcmath": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "ext-mbstring": "*",
+                "ext-sodium": "*",
+                "php": "~8.2.0 || ~8.3.0 || ~8.4.0",
+                "revolt/event-loop": "^1.0.6"
+            },
+            "require-dev": {
+                "carthage-software/mago": "~0.13.1",
+                "php-coveralls/php-coveralls": "^2.7.0",
+                "php-standard-library/psalm-plugin": "^2.3.0",
+                "phpbench/phpbench": "^1.2.15",
+                "phpunit/phpunit": "^9.6.18",
+                "roave/infection-static-analysis-plugin": "^1.36.0",
+                "vimeo/psalm": "^6.0.0"
+            },
+            "suggest": {
+                "php-standard-library/phpstan-extension": "PHPStan integration",
+                "php-standard-library/psalm-plugin": "Psalm integration"
+            },
+            "type": "library",
+            "extra": {
+                "thanks": {
+                    "url": "https://github.com/hhvm/hsl",
+                    "name": "hhvm/hsl"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/bootstrap.php"
+                ],
+                "psr-4": {
+                    "Psl\\": "src/Psl"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "azjezz",
+                    "email": "azjezz@protonmail.com"
+                }
+            ],
+            "description": "PHP Standard Library",
+            "support": {
+                "issues": "https://github.com/azjezz/psl/issues",
+                "source": "https://github.com/azjezz/psl/tree/3.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/azjezz",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-03-03T00:07:00+00:00"
+        },
+        {
+            "name": "maglnet/composer-require-checker",
+            "version": "4.18.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/maglnet/ComposerRequireChecker.git",
+                "reference": "de930e82bb61e0161d909696950692523b8eaa3f"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/maglnet/ComposerRequireChecker/zipball/de930e82bb61e0161d909696950692523b8eaa3f",
+                "reference": "de930e82bb61e0161d909696950692523b8eaa3f",
+                "shasum": ""
+            },
+            "require": {
+                "azjezz/psl": "^3.2.0",
                 "composer-runtime-api": "^2.0.0",
                 "ext-phar": "*",
-                "nikic/php-parser": "^5.5.0",
+                "nikic/php-parser": "^5.4.0",
                 "php": "~8.2.0 || ~8.3.0 || ~8.4.0 || ~8.5.0",
-                "symfony/console": "^6.4.1 || ^7.0.1",
-                "webmozart/assert": "^1.11.0",
+                "symfony/console": "^7.2.1",
                 "webmozart/glob": "^4.7.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^13.0.1",
+                "doctrine/coding-standard": "^14.0.0",
                 "ext-zend-opcache": "*",
                 "phing/phing": "^3.0.1",
+                "php-standard-library/phpstan-extension": "^2.0",
+                "php-standard-library/psalm-plugin": "^2.3",
                 "phpstan/phpstan": "^2.1.19",
                 "phpunit/phpunit": "^11.5.27",
                 "psalm/plugin-phpunit": "^0.19.5",
@@ -84,9 +160,9 @@
             ],
             "support": {
                 "issues": "https://github.com/maglnet/ComposerRequireChecker/issues",
-                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/4.17.0"
+                "source": "https://github.com/maglnet/ComposerRequireChecker/tree/4.18.0"
             },
-            "time": "2025-10-30T08:46:55+00:00"
+            "time": "2025-10-30T11:58:39+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -198,6 +274,78 @@
                 "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
             "time": "2021-11-05T16:47:00+00:00"
+        },
+        {
+            "name": "revolt/event-loop",
+            "version": "v1.0.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/revoltphp/event-loop.git",
+                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/revoltphp/event-loop/zipball/09bf1bf7f7f574453efe43044b06fafe12216eb3",
+                "reference": "09bf1bf7f7f574453efe43044b06fafe12216eb3",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=8.1"
+            },
+            "require-dev": {
+                "ext-json": "*",
+                "jetbrains/phpstorm-stubs": "^2019.3",
+                "phpunit/phpunit": "^9",
+                "psalm/phar": "^5.15"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-main": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Revolt\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Aaron Piotrowski",
+                    "email": "aaron@trowski.com"
+                },
+                {
+                    "name": "Cees-Jan Kiewiet",
+                    "email": "ceesjank@gmail.com"
+                },
+                {
+                    "name": "Christian Lück",
+                    "email": "christian@clue.engineering"
+                },
+                {
+                    "name": "Niklas Keller",
+                    "email": "me@kelunik.com"
+                }
+            ],
+            "description": "Rock-solid event loop for concurrent PHP applications.",
+            "keywords": [
+                "async",
+                "asynchronous",
+                "concurrency",
+                "event",
+                "event-loop",
+                "non-blocking",
+                "scheduler"
+            ],
+            "support": {
+                "issues": "https://github.com/revoltphp/event-loop/issues",
+                "source": "https://github.com/revoltphp/event-loop/tree/v1.0.7"
+            },
+            "time": "2025-01-25T19:27:39+00:00"
         },
         {
             "name": "symfony/console",
@@ -875,64 +1023,6 @@
                 }
             ],
             "time": "2025-09-11T14:36:48+00:00"
-        },
-        {
-            "name": "webmozart/assert",
-            "version": "1.12.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/webmozarts/assert.git",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/webmozarts/assert/zipball/9be6926d8b485f55b9229203f962b51ed377ba68",
-                "reference": "9be6926d8b485f55b9229203f962b51ed377ba68",
-                "shasum": ""
-            },
-            "require": {
-                "ext-ctype": "*",
-                "ext-date": "*",
-                "ext-filter": "*",
-                "php": "^7.2 || ^8.0"
-            },
-            "suggest": {
-                "ext-intl": "",
-                "ext-simplexml": "",
-                "ext-spl": ""
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.10-dev"
-                }
-            },
-            "autoload": {
-                "psr-4": {
-                    "Webmozart\\Assert\\": "src/"
-                }
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Bernhard Schussek",
-                    "email": "bschussek@gmail.com"
-                }
-            ],
-            "description": "Assertions to validate method input/output with nice error messages.",
-            "keywords": [
-                "assert",
-                "check",
-                "validate"
-            ],
-            "support": {
-                "issues": "https://github.com/webmozarts/assert/issues",
-                "source": "https://github.com/webmozarts/assert/tree/1.12.1"
-            },
-            "time": "2025-10-29T15:56:20+00:00"
         },
         {
             "name": "webmozart/glob",


### PR DESCRIPTION
Also, bumps dev deps and refreshes the lock.

Please don't merge… Unless we want to release this with v2 beta of fast-route.

The BC break involves adding `ConfigureRoutes` to the union of `FastRouteRouter`'s constructor. Considering it's soft final, and `RouteCollector` implements `ConfigureRoutes`, it doesn't seem like a BC break to me…